### PR TITLE
Add data field to PMCreditCardData 

### DIFF
--- a/src/main/java/com/wepay/model/data/PMCreditCardData.java
+++ b/src/main/java/com/wepay/model/data/PMCreditCardData.java
@@ -1,12 +1,19 @@
 package com.wepay.model.data;
+
 import org.json.*;
+import java.util.Map;
 
 public class PMCreditCardData {
-	public Long id;
-    
-	public static JSONObject buildCreditCard(PMCreditCardData info) throws JSONException {
-		JSONObject o = new JSONObject();
-		o.put("id", info.id);
-		return o;
-	}
+    public Long id;
+
+    public Map<String, Object> data;
+
+    public static JSONObject buildCreditCard(PMCreditCardData info) throws JSONException {
+        JSONObject o = new JSONObject();
+        o.put("id", info.id);
+        if (info.data != null) {
+            o.put("data", info.data);
+        }
+        return o;
+    }
 }


### PR DESCRIPTION
The PMCreditCardData object does not contain the data field. We need this data field to be able to send across a transaction_token param for EMV transactions.