### PR TITLE
Resolved '1005: failed to parse JSON' error for special characters

### DIFF
--- a/src/main/java/com/wepay/net/WePayResource.java
+++ b/src/main/java/com/wepay/net/WePayResource.java
@@ -63,7 +63,7 @@ public class WePayResource {
 	public static String request(String call, JSONObject params, String accessToken) throws WePayException, IOException {
 		HttpsURLConnection connection = httpsConnect(call, accessToken);
 		DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
-		wr.writeBytes(params.toString());
+		wr.write(params.toString().getBytes("UTF-8"));
 		wr.flush();
 		wr.close();
 		boolean error = false;


### PR DESCRIPTION
This is a code change made from an Infusionsoft team to address a recent issue encountered when attempting the following calls (including, but not limited to these calls) with the Java SDK:

- Creating an account with endpoint **/account/create** providing special characters in the name field.
> Providing a name with Latin special characters (e.g. à ȧ) or other signs (e.g. ©™) will result in a failed response with the code "1005" and the description "unable to parse json"

- Creating a credit card with endpoint **credit/card/create** providing special characters in the  user_name field
> Providing a name with Latin special characters (e.g. à ȧ) or other signs (e.g. ©™) will result in a failed response with the code "1005" and the description "unable to parse json"

We suspect the SDK was not properly encoding the JSON as UTF-8 on transmission, or it is somehow being overwritten when JSON is sent over.

We have been in communication with WePay support, and the following support tickets were made in order to track this particular issue:
829531
835128

We believe the code change provided is a 'possible' solution to the issue, where it encodes all parameters on the JSON object to UTF-8 before transmission. This has been tested on our end with various characters and determined to successfully make the API calls (mentioned above) with special characters, without problems. Please take a look. If you have found a more effective solution, please let us know.

Thank you.