### PR TITLE
Add support for accented characters.

### DIFF
--- a/src/main/java/com/wepay/net/WePayResource.java
+++ b/src/main/java/com/wepay/net/WePayResource.java
@@ -5,7 +5,10 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -62,8 +65,8 @@ public class WePayResource {
 	
 	public static String request(String call, JSONObject params, String accessToken) throws WePayException, IOException {
 		HttpsURLConnection connection = httpsConnect(call, accessToken);
-		DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
-		wr.writeBytes(params.toString());
+		Writer wr=new OutputStreamWriter(connection.getOutputStream(), StandardCharsets.UTF_8);
+		wr.write(params.toString());
 		wr.flush();
 		wr.close();
 		boolean error = false;

--- a/src/main/java/com/wepay/net/WePayResource.java
+++ b/src/main/java/com/wepay/net/WePayResource.java
@@ -1,7 +1,6 @@
 package com.wepay.net;
 
 import java.io.BufferedReader;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;


### PR DESCRIPTION

The method DataOutputStream.writeBytes method is not suitable for any character encoding. This does not produce correct UTF-8

Its documentation says:

> Each character in the string is written out, in sequence, by discarding its high eight bits.